### PR TITLE
Refactor goal structure to single Term type

### DIFF
--- a/lib/providers/db_provider.dart
+++ b/lib/providers/db_provider.dart
@@ -1,7 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:isar/isar.dart';
 
-import '../models/short_term.dart';
 import '../services/isar_service.dart';
 
 final isarServiceProvider = Provider<IsarService>((ref) {

--- a/lib/providers/term_providers.dart
+++ b/lib/providers/term_providers.dart
@@ -37,8 +37,8 @@ final termsByDreamProvider =
 });
 
 final termsByParentProvider =
-    StreamProvider.autoDispose.family<List<Term>, int>((ref, parentGoalId) {
-  return ref.read(termRepoProvider).watchChildren(parentGoalId);
+    StreamProvider.autoDispose.family<List<Term>, int>((ref, parentId) {
+  return ref.read(termRepoProvider).watchChildren(parentId);
 });
 
 // Unified: all top-level terms

--- a/lib/providers/term_providers.dart
+++ b/lib/providers/term_providers.dart
@@ -1,49 +1,18 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:isar/isar.dart';
 
 import '../models/dream.dart';
-import '../models/long_term.dart';
-import '../models/short_term.dart';
 import '../providers/db_provider.dart';
 import '../repositories/term_repositories.dart';
 import '../repositories/tag_repository.dart';
 import '../models/tag.dart';
-import '../repositories/term_repositories.dart';
 
 final dreamRepoProvider = Provider<DreamRepository>((ref) {
   final db = ref.read(isarServiceProvider);
   return DreamRepository(db);
 });
 
-final longTermRepoProvider = Provider<LongTermRepository>((ref) {
-  final db = ref.read(isarServiceProvider);
-  return LongTermRepository(db);
-});
-
-final shortTermRepoProvider = Provider<ShortTermRepository>((ref) {
-  final db = ref.read(isarServiceProvider);
-  return ShortTermRepository(db);
-});
-
 final dreamsProvider = StreamProvider.autoDispose<List<Dream>>((ref) {
   return ref.read(dreamRepoProvider).watchAll();
-});
-
-final longTermsByDreamProvider = StreamProvider.autoDispose.family<List<LongTerm>, int?>((ref, dreamId) {
-  return ref.read(longTermRepoProvider).watchByDream(dreamId);
-});
-
-final shortTermsByLongProvider = StreamProvider.autoDispose.family<List<ShortTerm>, int?>((ref, longId) {
-  return ref.read(shortTermRepoProvider).watchByLongTerm(longId);
-});
-
-// Convenience providers for all items
-final allLongTermsProvider = StreamProvider.autoDispose<List<LongTerm>>((ref) {
-  return ref.read(longTermRepoProvider).watchByDream(null);
-});
-
-final allShortTermsProvider = StreamProvider.autoDispose<List<ShortTerm>>((ref) {
-  return ref.read(shortTermRepoProvider).watchByLongTerm(null);
 });
 
 // Tags
@@ -62,20 +31,22 @@ final termRepoProvider = Provider<TermRepository>((ref) {
   return TermRepository(db);
 });
 
-final termsByDreamProvider = StreamProvider.autoDispose.family<List<Term>, int?>((ref, dreamId) {
+final termsByDreamProvider =
+    StreamProvider.autoDispose.family<List<Term>, int?>((ref, dreamId) {
   return ref.read(termRepoProvider).watchByDream(dreamId);
 });
 
-final termsByParentProvider = StreamProvider.autoDispose.family<List<Term>, int>((ref, parentGoalId) {
+final termsByParentProvider =
+    StreamProvider.autoDispose.family<List<Term>, int>((ref, parentGoalId) {
   return ref.read(termRepoProvider).watchChildren(parentGoalId);
 });
 
-// Unified: all top-level terms (formerly LongTerm)
+// Unified: all top-level terms
 final allTopTermsProvider = StreamProvider.autoDispose<List<Term>>((ref) {
   return ref.read(termRepoProvider).watchByDream(null);
 });
 
-// Unified: all child terms (formerly ShortTerm under any parent)
+// Unified: all child terms
 final allChildTermsProvider = StreamProvider.autoDispose<List<Term>>((ref) {
   return ref.read(termRepoProvider).watchAllChildren();
 });
@@ -84,15 +55,4 @@ final allChildTermsProvider = StreamProvider.autoDispose<List<Term>>((ref) {
 final termWithTagsProvider =
     StreamProvider.autoDispose.family<TermWithTags?, int>((ref, id) {
   return ref.read(termRepoProvider).watchWithTags(id);
-});
-
-// LongTerm with tags (for Maps UI without per-build DB calls)
-final longTermWithTagsProvider =
-    StreamProvider.autoDispose.family<GoalWithTags?, int>((ref, id) {
-  return ref.read(longTermRepoProvider).watchWithTags(id);
-});
-
-final shortTermWithTagsProvider =
-    StreamProvider.autoDispose.family<ShortTermWithTags?, int>((ref, id) {
-  return ref.read(shortTermRepoProvider).watchWithTags(id);
 });

--- a/lib/repositories/task_repository.dart
+++ b/lib/repositories/task_repository.dart
@@ -60,10 +60,10 @@ class TaskRepository {
   }
 
   // Watch tasks linked to a specific Term
-  Stream<List<Task>> watchByGoal(int goalId) {
+  Stream<List<Task>> watchByTerm(int termId) {
     return _isar.tasks
         .filter()
-        .shortTermIdEqualTo(goalId)
+        .shortTermIdEqualTo(termId)
         .sortByCreatedAt()
         .watch(fireImmediately: true)
         .asBroadcastStream();

--- a/lib/repositories/task_repository.dart
+++ b/lib/repositories/task_repository.dart
@@ -59,18 +59,14 @@ class TaskRepository {
     return q.watch(fireImmediately: true).asBroadcastStream();
   }
 
-  Stream<List<Task>> watchByShortTerm(int shortTermId) {
+  // Watch tasks linked to a specific Term
+  Stream<List<Task>> watchByGoal(int goalId) {
     return _isar.tasks
         .filter()
-        .shortTermIdEqualTo(shortTermId)
+        .shortTermIdEqualTo(goalId)
         .sortByCreatedAt()
         .watch(fireImmediately: true)
         .asBroadcastStream();
-  }
-
-  // Unified naming: watch tasks by Term (maps to ShortTerm under the hood)
-  Stream<List<Task>> watchByGoal(int goalId) {
-    return watchByShortTerm(goalId);
   }
 
   Stream<List<Task>> watchUnlinked() {

--- a/lib/repositories/term_repositories.dart
+++ b/lib/repositories/term_repositories.dart
@@ -67,7 +67,7 @@ class Term {
 
   final int id;
   final String title;
-  final int? parentId; // null for top-level goal
+  final int? parentId; // null for top-level term
   final int? dreamId; // non-null for top-level; derived for child
   final int priority;
   final DateTime? dueAt;
@@ -80,24 +80,28 @@ class TermRepository {
   final IsarService _db;
   Isar get _isar => _db.isar;
 
-  // Top-level goals under a Dream (LongTerm)
-  Stream<List<Term>> watchByDream(int? dreamId, {bool includeArchived = false}) {
+  // Top-level terms under a Dream (LongTerm)
+  Stream<List<Term>> watchByDream(int? dreamId,
+      {bool includeArchived = false}) {
     final longRepo = LongTermRepository(_db);
     return longRepo.watchByDream(dreamId, includeArchived: includeArchived).map(
-      (list) => list.map((l) => Term.parent(l)).toList(),
-    );
+          (list) => list.map((l) => Term.parent(l)).toList(),
+        );
   }
 
   // Child terms under a Term (ShortTerm under LongTerm)
-  Stream<List<Term>> watchChildren(int parentGoalId, {bool includeArchived = false}) {
+  Stream<List<Term>> watchChildren(int parentId,
+      {bool includeArchived = false}) {
     final shortRepo = ShortTermRepository(_db);
     return shortRepo
-        .watchByLongTerm(parentGoalId, includeArchived: includeArchived)
+        .watchByLongTerm(parentId, includeArchived: includeArchived)
         .asyncMap((shorts) async {
       // Need dreamId for children; fetch the parent LongTerm once
-      final parent = await _isar.longTerms.get(parentGoalId);
+      final parent = await _isar.longTerms.get(parentId);
       final parentDreamId = parent?.dreamId;
-      return shorts.map((s) => Term.child(s, dreamIdOfParent: parentDreamId)).toList();
+      return shorts
+          .map((s) => Term.child(s, dreamIdOfParent: parentDreamId))
+          .toList();
     });
   }
 
@@ -121,54 +125,56 @@ class TermRepository {
   Future<int> addTerm({
     required String title,
     required int dreamId,
-    int? parentGoalId,
+    int? parentId,
     int priority = 1,
     DateTime? dueAt,
   }) async {
-    if (parentGoalId == null) {
-      final ent = LongTerm(title: title, dreamId: dreamId, priority: priority, dueAt: dueAt);
+    if (parentId == null) {
+      final ent = LongTerm(
+          title: title, dreamId: dreamId, priority: priority, dueAt: dueAt);
       await LongTermRepository(_db).put(ent);
       return ent.id;
     } else {
-      final ent = ShortTerm(title: title, longTermId: parentGoalId, priority: priority, dueAt: dueAt);
+      final ent = ShortTerm(
+          title: title, longTermId: parentId, priority: priority, dueAt: dueAt);
       await ShortTermRepository(_db).put(ent);
       return ent.id;
     }
   }
 
-  Future<void> deleteTerm(Term goal) async {
+  Future<void> deleteTerm(Term term) async {
     // Try delete as LongTerm first; if not exists, try ShortTerm
-    final existedLong = await _isar.longTerms.get(goal.id) != null;
+    final existedLong = await _isar.longTerms.get(term.id) != null;
     if (existedLong) {
-      await LongTermRepository(_db).delete(goal.id);
+      await LongTermRepository(_db).delete(term.id);
       return;
     }
-    await ShortTermRepository(_db).delete(goal.id);
+    await ShortTermRepository(_db).delete(term.id);
   }
 
-  Future<void> updateTerm(Term goal, List<Tag> tags) async {
+  Future<void> updateTerm(Term term, List<Tag> tags) async {
     // Detect backing entity by presence in collections
-    final isLong = await _isar.longTerms.get(goal.id) != null;
+    final isLong = await _isar.longTerms.get(term.id) != null;
     if (isLong) {
       final repo = LongTermRepository(_db);
-      final entity = await repo.getById(goal.id);
+      final entity = await repo.getById(term.id);
       if (entity != null) {
         entity
-          ..title = goal.title
-          ..priority = goal.priority
-          ..dueAt = goal.dueAt
-          ..archived = goal.archived;
+          ..title = term.title
+          ..priority = term.priority
+          ..dueAt = term.dueAt
+          ..archived = term.archived;
         await repo.setTags(entity, tags);
       }
     } else {
       final repo = ShortTermRepository(_db);
-      final entity = await repo.getById(goal.id);
+      final entity = await repo.getById(term.id);
       if (entity != null) {
         entity
-          ..title = goal.title
-          ..priority = goal.priority
-          ..dueAt = goal.dueAt
-          ..archived = goal.archived;
+          ..title = term.title
+          ..priority = term.priority
+          ..dueAt = term.dueAt
+          ..archived = term.archived;
         await repo.setTags(entity, tags);
       }
     }
@@ -187,37 +193,37 @@ class TermRepository {
     }
   }
 
-  Future<List<Tag>> loadTags(Term goal) async {
-    final isLong = await _isar.longTerms.get(goal.id) != null;
+  Future<List<Tag>> loadTags(Term term) async {
+    final isLong = await _isar.longTerms.get(term.id) != null;
     if (isLong) {
-      final entity = await _isar.longTerms.get(goal.id);
+      final entity = await _isar.longTerms.get(term.id);
       if (entity == null) return const [];
       await entity.tags.load();
       return entity.tags.toList();
     } else {
-      final entity = await _isar.shortTerms.get(goal.id);
+      final entity = await _isar.shortTerms.get(term.id);
       if (entity == null) return const [];
       await entity.tags.load();
       return entity.tags.toList();
     }
   }
 
-  Future<void> archiveTerm(Term goal, {required bool archived}) async {
-    final isLong = await _isar.longTerms.get(goal.id) != null;
+  Future<void> archiveTerm(Term term, {required bool archived}) async {
+    final isLong = await _isar.longTerms.get(term.id) != null;
     if (isLong) {
-      final ent = await LongTermRepository(_db).getById(goal.id);
+      final ent = await LongTermRepository(_db).getById(term.id);
       if (ent == null) return;
       ent.archived = archived;
       await LongTermRepository(_db).put(ent);
     } else {
-      final ent = await ShortTermRepository(_db).getById(goal.id);
+      final ent = await ShortTermRepository(_db).getById(term.id);
       if (ent == null) return;
       ent.archived = archived;
       await ShortTermRepository(_db).put(ent);
     }
   }
 
-  // All child goals (across any parent)
+  // All child terms (across any parent)
   Stream<List<Term>> watchAllChildren({bool includeArchived = false}) {
     final shortRepo = ShortTermRepository(_db);
     return shortRepo
@@ -236,7 +242,7 @@ class TermRepository {
     });
   }
 
-  // Watch a single goal with tags (works for both top-level and child goals)
+  // Watch a single term with tags (works for both top-level and child terms)
   Stream<TermWithTags?> watchWithTags(int id) async* {
     final existedLong = await _isar.longTerms.get(id);
     if (existedLong != null) {
@@ -260,13 +266,15 @@ class TermRepository {
         final p = await _isar.longTerms.get(item.longTermId!);
         dreamId = p?.dreamId;
       }
-      return TermWithTags(item: Term.child(item, dreamIdOfParent: dreamId), tags: item.tags.toList());
+      return TermWithTags(
+          item: Term.child(item, dreamIdOfParent: dreamId),
+          tags: item.tags.toList());
     });
   }
 }
 
-class GoalWithTags {
-  GoalWithTags({required this.item, required this.tags});
+class LongTermWithTags {
+  LongTermWithTags({required this.item, required this.tags});
   final LongTerm item;
   final List<Tag> tags;
 }
@@ -294,15 +302,9 @@ class LongTermRepository {
     final q = dreamId == null
         ? (includeArchived
             ? _isar.longTerms.where().sortByCreatedAt()
-            : _isar.longTerms
-                .filter()
-                .archivedEqualTo(false)
-                .sortByCreatedAt())
+            : _isar.longTerms.filter().archivedEqualTo(false).sortByCreatedAt())
         : (includeArchived
-            ? _isar.longTerms
-                .filter()
-                .dreamIdEqualTo(dreamId)
-                .sortByCreatedAt()
+            ? _isar.longTerms.filter().dreamIdEqualTo(dreamId).sortByCreatedAt()
             : _isar.longTerms
                 .filter()
                 .dreamIdEqualTo(dreamId)
@@ -324,11 +326,13 @@ class LongTermRepository {
     return _isar.longTerms.get(id);
   }
 
-  Stream<GoalWithTags?> watchWithTags(int id) {
-    return _isar.longTerms.watchObject(id, fireImmediately: true).asyncMap((item) async {
+  Stream<LongTermWithTags?> watchWithTags(int id) {
+    return _isar.longTerms
+        .watchObject(id, fireImmediately: true)
+        .asyncMap((item) async {
       if (item == null) return null;
       await item.tags.load();
-      return GoalWithTags(item: item, tags: item.tags.toList());
+      return LongTermWithTags(item: item, tags: item.tags.toList());
     });
   }
 
@@ -409,7 +413,9 @@ class ShortTermRepository {
   }
 
   Stream<ShortTermWithTags?> watchWithTags(int id) {
-    return _isar.shortTerms.watchObject(id, fireImmediately: true).asyncMap((item) async {
+    return _isar.shortTerms
+        .watchObject(id, fireImmediately: true)
+        .asyncMap((item) async {
       if (item == null) return null;
       await item.tags.load();
       return ShortTermWithTags(item: item, tags: item.tags.toList());

--- a/lib/ui/maps/maps_page.dart
+++ b/lib/ui/maps/maps_page.dart
@@ -77,22 +77,22 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
   @override
   Widget build(BuildContext context) {
     final dreams = ref.watch(dreamsProvider).value ?? const <Dream>[];
-    final topGoals = ref.watch(allTopTermsProvider).value ?? const <Term>[];
-    final childGoals = ref.watch(allChildTermsProvider).value ?? const <Term>[];
+    final topTerms = ref.watch(allTopTermsProvider).value ?? const <Term>[];
+    final childTerms = ref.watch(allChildTermsProvider).value ?? const <Term>[];
     final tasks = ref.watch(tasksStreamProvider).value ?? const <Task>[];
 
     // Build hierarchy
     final nodes = <_Node>[];
     for (final d in dreams) {
       nodes.add(_Node.level0(d));
-      final parents = topGoals.where((g) => g.dreamId == d.id).toList();
+      final parents = topTerms.where((g) => g.dreamId == d.id).toList();
       for (final p in parents) {
         nodes.add(_Node.level1Term(p, parentId: d.id));
-        final children = childGoals.where((c) => c.parentId == p.id).toList();
+        final children = childTerms.where((c) => c.parentId == p.id).toList();
         for (final c in children) {
           nodes.add(_Node.level2Term(c, parentId: p.id));
         }
-        // Append tasks under each parent goal as level 3 nodes
+        // Append tasks under each parent term as level 3 nodes
         final childrenT = tasks.where((t) => t.shortTermId == p.id).toList();
         for (final t in childrenT) {
           nodes.add(_Node.level3(t, parentId: p.id));
@@ -116,7 +116,11 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
     double minX = double.infinity, minY = double.infinity;
     double maxX = -double.infinity, maxY = -double.infinity;
     // Pre-calc canvas height from rows
-    double totalHeight = pad * 2 + nodeH * 3 + vGap * 2 + taskH + vGap; // leave space for tasks row
+    double totalHeight = pad * 2 +
+        nodeH * 3 +
+        vGap * 2 +
+        taskH +
+        vGap; // leave space for tasks row
 
     for (var i = 0; i < dreamIds.length; i++) {
       final dx = pad + i * (nodeW + 240);
@@ -125,7 +129,7 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
       minY = math.min(minY, pad);
       maxX = math.max(maxX, dx + nodeW);
       maxY = math.max(maxY, pad + nodeH);
-      final lp = topGoals.where((g) => g.dreamId == dreamIds[i]).toList();
+      final lp = topTerms.where((g) => g.dreamId == dreamIds[i]).toList();
       if (lp.isEmpty) continue;
       final baseX = dx - ((lp.length - 1) / 2) * (nodeW + hGap);
       for (var j = 0; j < lp.length; j++) {
@@ -136,7 +140,7 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
         minY = math.min(minY, ly);
         maxX = math.max(maxX, lx + nodeW);
         maxY = math.max(maxY, ly + nodeH);
-        final sp = childGoals.where((s) => s.parentId == lp[j].id).toList();
+        final sp = childTerms.where((s) => s.parentId == lp[j].id).toList();
         if (sp.isEmpty) continue;
         final sBaseX = lx - ((sp.length - 1) / 2) * (nodeW + hGap / 2);
         for (var k = 0; k < sp.length; k++) {
@@ -159,7 +163,7 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
     };
     // Collect clusters (centered at long center)
     final clusters = <_TaskCluster>[];
-    for (final g in topGoals) {
+    for (final g in topTerms) {
       final lp = longPositions[g.id];
       if (lp == null) continue;
       final ts = tasks.where((t) => t.shortTermId == g.id).toList();
@@ -175,7 +179,8 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
     clusters.sort((a, b) => a.centerX.compareTo(b.centerX));
     double lastRight = -double.infinity;
     const minClusterGap = 24.0; // minimum gap between clusters
-    final taskRowY = pad + (nodeH + vGap) * 2 + nodeH + vGap; // below shorts with extra gap
+    final taskRowY =
+        pad + (nodeH + vGap) * 2 + nodeH + vGap; // below shorts with extra gap
     for (final c in clusters) {
       final width = c.tasks.length * (nodeW + taskHGap) - taskHGap;
       double left = c.centerX - width / 2;
@@ -217,33 +222,41 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
     final edges = <(_Node, _Node)>[];
     for (final n in nodes) {
       if (n.level == 1) {
-        final p = nodes.firstWhere((e) => e.id == n.parentId && e.level == 0, orElse: () => _Node.empty());
+        final p = nodes.firstWhere((e) => e.id == n.parentId && e.level == 0,
+            orElse: () => _Node.empty());
         if (!p.isEmpty) edges.add((p, n));
       } else if (n.level == 2) {
-        final p = nodes.firstWhere((e) => e.id == n.parentId && e.level == 1, orElse: () => _Node.empty());
+        final p = nodes.firstWhere((e) => e.id == n.parentId && e.level == 1,
+            orElse: () => _Node.empty());
         if (!p.isEmpty) edges.add((p, n));
       } else if (n.level == 3) {
-        final p = nodes.firstWhere((e) => e.id == n.parentId && e.level == 1, orElse: () => _Node.empty());
+        final p = nodes.firstWhere((e) => e.id == n.parentId && e.level == 1,
+            orElse: () => _Node.empty());
         if (!p.isEmpty) edges.add((p, n));
       }
     }
 
     // Canvas with pan/zoom
     // Fit-to-view setup
-    final newHash = nodes.fold<int>(0, (acc, n) => acc ^ n.id ^ (n.level << 4) ^ n.type.hashCode);
+    final newHash = nodes.fold<int>(
+        0, (acc, n) => acc ^ n.id ^ (n.level << 4) ^ n.type.hashCode);
 
     return LayoutBuilder(builder: (context, viewport) {
       // Auto-fit on content change
       if (newHash != _layoutHash && contentWidth > 0 && contentHeight > 0) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _layoutHash = newHash;
-          _fitToView(Size(viewport.maxWidth, viewport.maxHeight), contentWidth, contentHeight);
+          _fitToView(Size(viewport.maxWidth, viewport.maxHeight), contentWidth,
+              contentHeight);
         });
       }
 
-      void zoomIn() => _zoomTo((_tc.value.getMaxScaleOnAxis() * 1.2).clamp(_minScale, _maxScale));
-      void zoomOut() => _zoomTo((_tc.value.getMaxScaleOnAxis() / 1.2).clamp(_minScale, _maxScale));
-      void fit() => _fitToView(Size(viewport.maxWidth, viewport.maxHeight), contentWidth, contentHeight);
+      void zoomIn() => _zoomTo(
+          (_tc.value.getMaxScaleOnAxis() * 1.2).clamp(_minScale, _maxScale));
+      void zoomOut() => _zoomTo(
+          (_tc.value.getMaxScaleOnAxis() / 1.2).clamp(_minScale, _maxScale));
+      void fit() => _fitToView(Size(viewport.maxWidth, viewport.maxHeight),
+          contentWidth, contentHeight);
 
       return Stack(
         children: [
@@ -270,7 +283,8 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
                 ),
                 // Nodes
                 ...nodes.map((n) {
-                  final pos = normalized['${n.type}:${n.id}'] ?? const Offset(0, 0);
+                  final pos =
+                      normalized['${n.type}:${n.id}'] ?? const Offset(0, 0);
                   return Positioned(
                     left: pos.dx,
                     top: pos.dy,
@@ -303,7 +317,9 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
   void _fitToView(Size viewport, double contentWidth, double contentHeight) {
     final vw = viewport.width;
     final vh = viewport.height;
-    final scale = math.min(vw / contentWidth, vh / contentHeight).clamp(_minScale, _maxScale);
+    final scale = math
+        .min(vw / contentWidth, vh / contentHeight)
+        .clamp(_minScale, _maxScale);
     final tx = (vw - contentWidth * scale) / 2;
     final ty = (vh - contentHeight * scale) / 2;
     _tc.value = Matrix4.identity()
@@ -313,7 +329,8 @@ class _MapCanvasState extends ConsumerState<_MapCanvas> {
 }
 
 class _ZoomControls extends StatelessWidget {
-  const _ZoomControls({required this.onIn, required this.onOut, required this.onFit});
+  const _ZoomControls(
+      {required this.onIn, required this.onOut, required this.onFit});
   final VoidCallback onIn;
   final VoidCallback onOut;
   final VoidCallback onFit;
@@ -328,9 +345,16 @@ class _ZoomControls extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            IconButton(tooltip: '拡大', icon: const Icon(Icons.add), onPressed: onIn),
-            IconButton(tooltip: '縮小', icon: const Icon(Icons.remove), onPressed: onOut),
-            IconButton(tooltip: 'フィット', icon: const Icon(Icons.fit_screen), onPressed: onFit),
+            IconButton(
+                tooltip: '拡大', icon: const Icon(Icons.add), onPressed: onIn),
+            IconButton(
+                tooltip: '縮小',
+                icon: const Icon(Icons.remove),
+                onPressed: onOut),
+            IconButton(
+                tooltip: 'フィット',
+                icon: const Icon(Icons.fit_screen),
+                onPressed: onFit),
           ],
         ),
       ),
@@ -339,7 +363,15 @@ class _ZoomControls extends StatelessWidget {
 }
 
 class _Node {
-  _Node({required this.id, required this.title, required this.level, this.parentId, required this.type, this.priority, this.done, this.dueAt});
+  _Node(
+      {required this.id,
+      required this.title,
+      required this.level,
+      this.parentId,
+      required this.type,
+      this.priority,
+      this.done,
+      this.dueAt});
   final int id;
   final String title;
   final int level; // 0 dream, 1 long, 2 short
@@ -349,9 +381,12 @@ class _Node {
   final bool? done; // for task
   final DateTime? dueAt; // for task
 
-  static _Node level0(Dream d) => _Node(id: d.id, title: d.title, level: 0, type: 'dream');
-  static _Node level1Term(Term g, {required int parentId}) => _Node(id: g.id, title: g.title, level: 1, parentId: parentId, type: 'term');
-  static _Node level2Term(Term g, {required int parentId}) => _Node(id: g.id, title: g.title, level: 2, parentId: parentId, type: 'term');
+  static _Node level0(Dream d) =>
+      _Node(id: d.id, title: d.title, level: 0, type: 'dream');
+  static _Node level1Term(Term g, {required int parentId}) => _Node(
+      id: g.id, title: g.title, level: 1, parentId: parentId, type: 'term');
+  static _Node level2Term(Term g, {required int parentId}) => _Node(
+      id: g.id, title: g.title, level: 2, parentId: parentId, type: 'term');
   static _Node level3(Task t, {required int parentId}) => _Node(
         id: t.id,
         title: t.title,
@@ -368,7 +403,11 @@ class _Node {
 }
 
 class _EdgesPainter extends CustomPainter {
-  _EdgesPainter({required this.nodes, required this.positions, required this.nodeSize, required this.edges});
+  _EdgesPainter(
+      {required this.nodes,
+      required this.positions,
+      required this.nodeSize,
+      required this.edges});
   final List<_Node> nodes;
   final Map<String, Offset> positions;
   final Size nodeSize;
@@ -384,7 +423,8 @@ class _EdgesPainter extends CustomPainter {
     for (final (p, c) in edges) {
       final pPos = positions['${p.type}:${p.id}'] ?? Offset.zero;
       final cPos = positions['${c.type}:${c.id}'] ?? Offset.zero;
-      final pCenter = Offset(pPos.dx + nodeSize.width / 2, pPos.dy + nodeSize.height);
+      final pCenter =
+          Offset(pPos.dx + nodeSize.width / 2, pPos.dy + nodeSize.height);
       final cCenter = Offset(cPos.dx + nodeSize.width / 2, cPos.dy);
 
       final midY = (pCenter.dy + cCenter.dy) / 2;
@@ -397,7 +437,9 @@ class _EdgesPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _EdgesPainter oldDelegate) {
-    return oldDelegate.positions != positions || oldDelegate.nodes != nodes || oldDelegate.edges != edges;
+    return oldDelegate.positions != positions ||
+        oldDelegate.nodes != nodes ||
+        oldDelegate.edges != edges;
   }
 }
 
@@ -424,7 +466,8 @@ class _NodeCard extends ConsumerWidget {
           if (node.level == 1) {
             Navigator.of(context).push(
               MaterialPageRoute(
-                builder: (_) => TermTodoPage(goalId: node.id, goalTitle: node.title),
+                builder: (_) =>
+                    TermTodoPage(termId: node.id, termTitle: node.title),
               ),
             );
           } else if (node.level == 2) {
@@ -432,7 +475,8 @@ class _NodeCard extends ConsumerWidget {
               context: context,
               useSafeArea: true,
               isScrollControlled: true,
-              builder: (context) => TermDetailSheet(goalId: node.id, title: node.title),
+              builder: (context) =>
+                  TermDetailSheet(termId: node.id, title: node.title),
             );
           } else if (node.type == 'task') {
             // Display-only for now
@@ -444,7 +488,7 @@ class _NodeCard extends ConsumerWidget {
             children: [
               Expanded(
                 child: switch (node.level) {
-                  1 => _GoalNodeContent(node: node),
+                  1 => _TermNodeContent(node: node),
                   3 => _TaskNodeContent(node: node),
                   _ => Text(
                       node.title,
@@ -456,99 +500,114 @@ class _NodeCard extends ConsumerWidget {
               ),
               if (node.level != 3)
                 PopupMenuButton<String>(
-                onSelected: (v) async {
-                  switch (v) {
-                    case 'add_child':
-                      // Create a top-level goal under Dream with a full form
-                      if (node.level == 0) {
-                        final allTags = ref.read(tagsProvider).value ??
-                            await ref.read(tagRepoProvider).watchAll().first;
-                        final created = await showDialog<_TermCreateResult>(
-                          context: context,
-                          builder: (_) => _CreateTermDialog(allTags: allTags),
-                        );
-                        if (created != null) {
-                          final id = await ref.read(termRepoProvider).addTerm(
-                                title: created.title,
-                                dreamId: node.id,
-                                priority: created.priority,
-                                dueAt: created.dueAt,
-                              );
-                          if (created.tags.isNotEmpty) {
-                            await ref.read(termRepoProvider).setTagsById(id, created.tags);
+                  onSelected: (v) async {
+                    switch (v) {
+                      case 'add_child':
+                        // Create a top-level term under Dream with a full form
+                        if (node.level == 0) {
+                          final allTags = ref.read(tagsProvider).value ??
+                              await ref.read(tagRepoProvider).watchAll().first;
+                          final created = await showDialog<_TermCreateResult>(
+                            context: context,
+                            builder: (_) => _CreateTermDialog(allTags: allTags),
+                          );
+                          if (created != null) {
+                            final id = await ref.read(termRepoProvider).addTerm(
+                                  title: created.title,
+                                  dreamId: node.id,
+                                  priority: created.priority,
+                                  dueAt: created.dueAt,
+                                );
+                            if (created.tags.isNotEmpty) {
+                              await ref
+                                  .read(termRepoProvider)
+                                  .setTagsById(id, created.tags);
+                            }
                           }
                         }
-                      }
-                      break;
-                    case 'edit':
-                      if (node.level == 0) {
-                        final repo = ref.read(dreamRepoProvider);
-                        final ent = await repo.getById(node.id);
-                        if (ent == null) break;
-                        final updated = await showDialog<Dream>(
-                          context: context,
-                          builder: (_) => _EditDreamDialog(initial: ent),
-                        );
-                        if (updated != null) {
-                          await repo.put(updated);
+                        break;
+                      case 'edit':
+                        if (node.level == 0) {
+                          final repo = ref.read(dreamRepoProvider);
+                          final ent = await repo.getById(node.id);
+                          if (ent == null) break;
+                          final updated = await showDialog<Dream>(
+                            context: context,
+                            builder: (_) => _EditDreamDialog(initial: ent),
+                          );
+                          if (updated != null) {
+                            await repo.put(updated);
+                          }
+                        } else if (node.level == 1) {
+                          final repo = ref.read(termRepoProvider);
+                          final ent = await repo.getById(node.id);
+                          if (ent == null) break;
+                          final allTags = ref.read(tagsProvider).value ??
+                              await ref.read(tagRepoProvider).watchAll().first;
+                          final initialTags = await repo.loadTags(ent);
+                          final updated = await showDialog<_TermEditResult>(
+                            context: context,
+                            builder: (_) => _EditTermDialog(
+                                initial: ent,
+                                allTags: allTags,
+                                initialTags: initialTags),
+                          );
+                          if (updated != null) {
+                            await repo.updateTerm(updated.item, updated.tags);
+                          }
                         }
-                      } else if (node.level == 1) {
-                        final repo = ref.read(termRepoProvider);
-                        final ent = await repo.getById(node.id);
-                        if (ent == null) break;
-                        final allTags = ref.read(tagsProvider).value ??
+                        break;
+                      case 'open_tasks':
+                        if (node.type == 'short') {
+                          await showModalBottomSheet(
+                            context: context,
+                            useSafeArea: true,
+                            isScrollControlled: true,
+                            builder: (context) => TermDetailSheet(
+                                termId: node.id, title: node.title),
+                          );
+                        }
+                        break;
+                      case 'edit_tags':
+                        final allTags =
                             await ref.read(tagRepoProvider).watchAll().first;
-                        final initialTags = await repo.loadTags(ent);
-                        final updated = await showDialog<_TermEditResult>(
+                        final current = await ref
+                            .read(termRepoProvider)
+                            .watchWithTags(node.id)
+                            .first;
+                        final picked = await showDialog<List<Tag>>(
                           context: context,
-                          builder: (_) => _EditTermDialog(initial: ent, allTags: allTags, initialTags: initialTags),
+                          builder: (context) => _TagPickerDialog(
+                            allTags: allTags,
+                            initial: current?.tags ?? const <Tag>[],
+                          ),
                         );
-                        if (updated != null) {
-                          await repo.updateTerm(updated.item, updated.tags);
+                        if (picked != null) {
+                          await ref
+                              .read(termRepoProvider)
+                              .setTagsById(node.id, picked);
                         }
-                      }
-                      break;
-                    case 'open_tasks':
-                      if (node.type == 'short') {
-                        await showModalBottomSheet(
-                          context: context,
-                          useSafeArea: true,
-                          isScrollControlled: true,
-                          builder: (context) => TermDetailSheet(goalId: node.id, title: node.title),
-                        );
-                      }
-                      break;
-                    case 'edit_tags':
-                      final allTags = await ref.read(tagRepoProvider).watchAll().first;
-                      final current = await ref.read(termRepoProvider).watchWithTags(node.id).first;
-                      final picked = await showDialog<List<Tag>>(
-                        context: context,
-                        builder: (context) => _TagPickerDialog(
-                          allTags: allTags,
-                          initial: current?.tags ?? const <Tag>[],
-                        ),
-                      );
-                      if (picked != null) {
-                        await ref.read(termRepoProvider).setTagsById(node.id, picked);
-                      }
-                      break;
-                  }
-                },
-                itemBuilder: (context) {
-                  final items = <PopupMenuEntry<String>>[];
-                  // Only allow creating a child term under a Dream
-                  if (node.level == 0) {
-                    items.add(const PopupMenuItem(value: 'add_child', child: Text('子を追加')));
-                  }
-                  if (node.level == 0 || node.level == 1) {
-                    items.add(const PopupMenuItem(value: 'edit', child: Text('編集')));
-                  }
-                  if (node.level == 2) {
-                    items.add(const PopupMenuItem(value: 'open_tasks', child: Text('タスクを管理')));
-                  }
-                  return items;
-                },
-              ),
+                        break;
+                    }
+                  },
+                  itemBuilder: (context) {
+                    final items = <PopupMenuEntry<String>>[];
+                    // Only allow creating a child term under a Dream
+                    if (node.level == 0) {
+                      items.add(const PopupMenuItem(
+                          value: 'add_child', child: Text('子を追加')));
+                    }
+                    if (node.level == 0 || node.level == 1) {
+                      items.add(const PopupMenuItem(
+                          value: 'edit', child: Text('編集')));
+                    }
+                    if (node.level == 2) {
+                      items.add(const PopupMenuItem(
+                          value: 'open_tasks', child: Text('タスクを管理')));
+                    }
+                    return items;
+                  },
+                ),
             ],
           ),
         ),
@@ -581,7 +640,9 @@ class _TaskNodeContent extends StatelessWidget {
       children: [
         Icon(
           node.done == true ? Icons.check_circle : Icons.radio_button_unchecked,
-          color: node.done == true ? Colors.green : Theme.of(context).disabledColor,
+          color: node.done == true
+              ? Colors.green
+              : Theme.of(context).disabledColor,
           size: 18,
         ),
         const SizedBox(width: 8),
@@ -599,16 +660,26 @@ class _TaskNodeContent extends StatelessWidget {
               const SizedBox(height: 4),
               Row(
                 children: [
-                  Container(width: 8, height: 8, decoration: BoxDecoration(color: _priorityColor(node.priority), shape: BoxShape.circle)),
+                  Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                          color: _priorityColor(node.priority),
+                          shape: BoxShape.circle)),
                   const SizedBox(width: 6),
                   if (node.dueAt != null)
                     Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 6, vertical: 2),
                       decoration: BoxDecoration(
-                        border: Border.all(color: Theme.of(context).dividerColor.withOpacity(0.2)),
+                        border: Border.all(
+                            color: Theme.of(context)
+                                .dividerColor
+                                .withOpacity(0.2)),
                         borderRadius: BorderRadius.circular(8),
                       ),
-                      child: Text('${node.dueAt!.month}/${node.dueAt!.day}', style: Theme.of(context).textTheme.bodySmall),
+                      child: Text('${node.dueAt!.month}/${node.dueAt!.day}',
+                          style: Theme.of(context).textTheme.bodySmall),
                     ),
                 ],
               ),
@@ -621,7 +692,8 @@ class _TaskNodeContent extends StatelessWidget {
 }
 
 class _TaskCluster {
-  _TaskCluster({required this.longId, required this.centerX, required this.tasks});
+  _TaskCluster(
+      {required this.longId, required this.centerX, required this.tasks});
   final int longId;
   final double centerX;
   final List<Task> tasks;
@@ -685,19 +757,26 @@ class _EditDreamDialogState extends State<_EditDreamDialog> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              TextField(controller: _title, decoration: const InputDecoration(labelText: 'タイトル'), autofocus: true),
+              TextField(
+                  controller: _title,
+                  decoration: const InputDecoration(labelText: 'タイトル'),
+                  autofocus: true),
               // 夢には優先度・期限は不要のため、編集項目から除外
             ],
           ),
         ),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
         FilledButton(
           onPressed: () {
             final d = Dream(
               id: widget.initial.id,
-              title: _title.text.trim().isEmpty ? widget.initial.title : _title.text.trim(),
+              title: _title.text.trim().isEmpty
+                  ? widget.initial.title
+                  : _title.text.trim(),
               // Keep existing values for non-editable fields
               priority: widget.initial.priority,
               dueAt: widget.initial.dueAt,
@@ -716,7 +795,10 @@ class _EditDreamDialogState extends State<_EditDreamDialog> {
 }
 
 class _EditTermDialog extends StatefulWidget {
-  const _EditTermDialog({required this.initial, required this.allTags, required this.initialTags});
+  const _EditTermDialog(
+      {required this.initial,
+      required this.allTags,
+      required this.initialTags});
   final Term initial;
   final List<Tag> allTags;
   final List<Tag> initialTags;
@@ -767,7 +849,10 @@ class _EditTermDialogState extends State<_EditTermDialog> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              TextField(controller: _title, decoration: const InputDecoration(labelText: 'タイトル'), autofocus: true),
+              TextField(
+                  controller: _title,
+                  decoration: const InputDecoration(labelText: 'タイトル'),
+                  autofocus: true),
               const SizedBox(height: 12),
               const Text('タグ'),
               const SizedBox(height: 8),
@@ -799,9 +884,20 @@ class _EditTermDialogState extends State<_EditTermDialog> {
               Wrap(
                 spacing: 8,
                 children: [
-                  ChoiceChip(label: const Text('なし'), selected: _dueAt == null, onSelected: (_) => setState(() => _dueAt = null)),
-                  ChoiceChip(label: const Text('今日'), selected: false, onSelected: (_) => setState(() => _dueAt = DateTime.now())),
-                  ChoiceChip(label: const Text('明日'), selected: false, onSelected: (_) => setState(() => _dueAt = DateTime.now().add(const Duration(days: 1)))),
+                  ChoiceChip(
+                      label: const Text('なし'),
+                      selected: _dueAt == null,
+                      onSelected: (_) => setState(() => _dueAt = null)),
+                  ChoiceChip(
+                      label: const Text('今日'),
+                      selected: false,
+                      onSelected: (_) =>
+                          setState(() => _dueAt = DateTime.now())),
+                  ChoiceChip(
+                      label: const Text('明日'),
+                      selected: false,
+                      onSelected: (_) => setState(() => _dueAt =
+                          DateTime.now().add(const Duration(days: 1)))),
                   ActionChip(label: const Text('日付指定'), onPressed: pickDate),
                 ],
               ),
@@ -811,10 +907,22 @@ class _EditTermDialogState extends State<_EditTermDialog> {
               Wrap(
                 spacing: 8,
                 children: [
-                  ChoiceChip(label: const Text('低'), selected: _priority == 0, onSelected: (_) => setState(() => _priority = 0)),
-                  ChoiceChip(label: const Text('中'), selected: _priority == 1, onSelected: (_) => setState(() => _priority = 1)),
-                  ChoiceChip(label: const Text('高'), selected: _priority == 2, onSelected: (_) => setState(() => _priority = 2)),
-                  ChoiceChip(label: const Text('最優先'), selected: _priority == 3, onSelected: (_) => setState(() => _priority = 3)),
+                  ChoiceChip(
+                      label: const Text('低'),
+                      selected: _priority == 0,
+                      onSelected: (_) => setState(() => _priority = 0)),
+                  ChoiceChip(
+                      label: const Text('中'),
+                      selected: _priority == 1,
+                      onSelected: (_) => setState(() => _priority = 1)),
+                  ChoiceChip(
+                      label: const Text('高'),
+                      selected: _priority == 2,
+                      onSelected: (_) => setState(() => _priority = 2)),
+                  ChoiceChip(
+                      label: const Text('最優先'),
+                      selected: _priority == 3,
+                      onSelected: (_) => setState(() => _priority = 3)),
                 ],
               ),
             ],
@@ -822,12 +930,16 @@ class _EditTermDialogState extends State<_EditTermDialog> {
         ),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
         FilledButton(
           onPressed: () {
             final updated = Term(
               id: widget.initial.id,
-              title: _title.text.trim().isEmpty ? widget.initial.title : _title.text.trim(),
+              title: _title.text.trim().isEmpty
+                  ? widget.initial.title
+                  : _title.text.trim(),
               parentId: widget.initial.parentId,
               dreamId: widget.initial.dreamId,
               priority: _priority,
@@ -835,9 +947,11 @@ class _EditTermDialogState extends State<_EditTermDialog> {
               archived: widget.initial.archived,
               color: widget.initial.color,
             );
-            final selectedTags =
-                widget.allTags.where((t) => _selectedTagIds.contains(t.id)).toList();
-            Navigator.pop(context, _TermEditResult(item: updated, tags: selectedTags));
+            final selectedTags = widget.allTags
+                .where((t) => _selectedTagIds.contains(t.id))
+                .toList();
+            Navigator.pop(
+                context, _TermEditResult(item: updated, tags: selectedTags));
           },
           child: const Text('保存'),
         )
@@ -887,7 +1001,10 @@ class _CreateTermDialogState extends State<_CreateTermDialog> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              TextField(controller: _title, decoration: const InputDecoration(labelText: 'タイトル'), autofocus: true),
+              TextField(
+                  controller: _title,
+                  decoration: const InputDecoration(labelText: 'タイトル'),
+                  autofocus: true),
               const SizedBox(height: 12),
               const Text('タグ'),
               const SizedBox(height: 8),
@@ -919,9 +1036,20 @@ class _CreateTermDialogState extends State<_CreateTermDialog> {
               Wrap(
                 spacing: 8,
                 children: [
-                  ChoiceChip(label: const Text('なし'), selected: _dueAt == null, onSelected: (_) => setState(() => _dueAt = null)),
-                  ChoiceChip(label: const Text('今日'), selected: false, onSelected: (_) => setState(() => _dueAt = DateTime.now())),
-                  ChoiceChip(label: const Text('明日'), selected: false, onSelected: (_) => setState(() => _dueAt = DateTime.now().add(const Duration(days: 1)))),
+                  ChoiceChip(
+                      label: const Text('なし'),
+                      selected: _dueAt == null,
+                      onSelected: (_) => setState(() => _dueAt = null)),
+                  ChoiceChip(
+                      label: const Text('今日'),
+                      selected: false,
+                      onSelected: (_) =>
+                          setState(() => _dueAt = DateTime.now())),
+                  ChoiceChip(
+                      label: const Text('明日'),
+                      selected: false,
+                      onSelected: (_) => setState(() => _dueAt =
+                          DateTime.now().add(const Duration(days: 1)))),
                   ActionChip(label: const Text('日付指定'), onPressed: pickDate),
                 ],
               ),
@@ -931,10 +1059,22 @@ class _CreateTermDialogState extends State<_CreateTermDialog> {
               Wrap(
                 spacing: 8,
                 children: [
-                  ChoiceChip(label: const Text('低'), selected: _priority == 0, onSelected: (_) => setState(() => _priority = 0)),
-                  ChoiceChip(label: const Text('中'), selected: _priority == 1, onSelected: (_) => setState(() => _priority = 1)),
-                  ChoiceChip(label: const Text('高'), selected: _priority == 2, onSelected: (_) => setState(() => _priority = 2)),
-                  ChoiceChip(label: const Text('最優先'), selected: _priority == 3, onSelected: (_) => setState(() => _priority = 3)),
+                  ChoiceChip(
+                      label: const Text('低'),
+                      selected: _priority == 0,
+                      onSelected: (_) => setState(() => _priority = 0)),
+                  ChoiceChip(
+                      label: const Text('中'),
+                      selected: _priority == 1,
+                      onSelected: (_) => setState(() => _priority = 1)),
+                  ChoiceChip(
+                      label: const Text('高'),
+                      selected: _priority == 2,
+                      onSelected: (_) => setState(() => _priority = 2)),
+                  ChoiceChip(
+                      label: const Text('最優先'),
+                      selected: _priority == 3,
+                      onSelected: (_) => setState(() => _priority = 3)),
                 ],
               ),
             ],
@@ -942,7 +1082,9 @@ class _CreateTermDialogState extends State<_CreateTermDialog> {
         ),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
         FilledButton(
           onPressed: () {
             final t = _title.text.trim();
@@ -950,8 +1092,13 @@ class _CreateTermDialogState extends State<_CreateTermDialog> {
               Navigator.pop(context);
               return;
             }
-            final tags = widget.allTags.where((e) => _selectedTagIds.contains(e.id)).toList();
-            Navigator.pop(context, _TermCreateResult(title: t, tags: tags, priority: _priority, dueAt: _dueAt));
+            final tags = widget.allTags
+                .where((e) => _selectedTagIds.contains(e.id))
+                .toList();
+            Navigator.pop(
+                context,
+                _TermCreateResult(
+                    title: t, tags: tags, priority: _priority, dueAt: _dueAt));
           },
           child: const Text('作成'),
         ),
@@ -960,7 +1107,6 @@ class _CreateTermDialogState extends State<_CreateTermDialog> {
   }
 }
 
-
 class _TermEditResult {
   _TermEditResult({required this.item, required this.tags});
   final Term item;
@@ -968,13 +1114,16 @@ class _TermEditResult {
 }
 
 class _TermCreateResult {
-  _TermCreateResult({required this.title, required this.tags, required this.priority, required this.dueAt});
+  _TermCreateResult(
+      {required this.title,
+      required this.tags,
+      required this.priority,
+      required this.dueAt});
   final String title;
   final List<Tag> tags;
   final int priority;
   final DateTime? dueAt;
 }
-
 
 class _TagPickerDialogState extends State<_TagPickerDialog> {
   late Set<int> _selectedIds;
@@ -1008,16 +1157,21 @@ class _TagPickerDialogState extends State<_TagPickerDialog> {
                             });
                           },
                           title: Text(t.name),
-                          secondary: CircleAvatar(backgroundColor: Color(t.color)),
+                          secondary:
+                              CircleAvatar(backgroundColor: Color(t.color)),
                         ))
                     .toList(),
               ),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
         FilledButton(
           onPressed: () {
-            final result = widget.allTags.where((t) => _selectedIds.contains(t.id)).toList();
+            final result = widget.allTags
+                .where((t) => _selectedIds.contains(t.id))
+                .toList();
             Navigator.pop(context, result);
           },
           child: const Text('保存'),
@@ -1027,8 +1181,8 @@ class _TagPickerDialogState extends State<_TagPickerDialog> {
   }
 }
 
-class _GoalNodeContent extends ConsumerWidget {
-  const _GoalNodeContent({required this.node});
+class _TermNodeContent extends ConsumerWidget {
+  const _TermNodeContent({required this.node});
   final _Node node;
 
   @override
@@ -1054,12 +1208,15 @@ class _GoalNodeContent extends ConsumerWidget {
               runSpacing: -6,
               children: tags
                   .map((t) => Chip(
-                        label: Text('#${t.name}', style: Theme.of(context).textTheme.bodySmall),
+                        label: Text('#${t.name}',
+                            style: Theme.of(context).textTheme.bodySmall),
                         visualDensity: VisualDensity.compact,
                         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 0),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 0),
                         backgroundColor: Color(t.color).withOpacity(0.15),
-                        side: BorderSide(color: Color(t.color).withOpacity(0.35)),
+                        side:
+                            BorderSide(color: Color(t.color).withOpacity(0.35)),
                       ))
                   .toList(),
             ),
@@ -1082,8 +1239,12 @@ Future<String?> _askTitle(BuildContext context, String title) async {
         onSubmitted: (_) => Navigator.of(context).pop(controller.text.trim()),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
-        FilledButton(onPressed: () => Navigator.pop(context, controller.text.trim()), child: const Text('追加')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
+        FilledButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('追加')),
       ],
     ),
   );

--- a/lib/ui/terms/terms_page.dart
+++ b/lib/ui/terms/terms_page.dart
@@ -49,7 +49,9 @@ class TermsPage extends ConsumerWidget {
                         onPressed: () async {
                           final title = await _askTitle(context, '夢を追加');
                           if (title != null) {
-                            await ref.read(dreamRepoProvider).put(Dream(title: title));
+                            await ref
+                                .read(dreamRepoProvider)
+                                .put(Dream(title: title));
                           }
                         },
                         icon: const Icon(Icons.add),
@@ -63,7 +65,8 @@ class TermsPage extends ConsumerWidget {
                         ? const Center(child: Text('まだTermがありません'))
                         : ListView.builder(
                             itemCount: dreams.length,
-                            itemBuilder: (context, i) => DreamTile(dream: dreams[i]),
+                            itemBuilder: (context, i) =>
+                                DreamTile(dream: dreams[i]),
                           ),
                   ),
                 ],
@@ -95,7 +98,9 @@ class DreamTile extends ConsumerWidget {
               onPressed: () async {
                 final title = await _askTitle(context, 'Termを追加');
                 if (title != null) {
-                  await ref.read(termRepoProvider).addTerm(title: title, dreamId: dream.id);
+                  await ref
+                      .read(termRepoProvider)
+                      .addTerm(title: title, dreamId: dream.id);
                 }
               },
             ),
@@ -112,7 +117,9 @@ class DreamTile extends ConsumerWidget {
                 }
               },
               itemBuilder: (context) => [
-                PopupMenuItem(value: dream.archived ? 'unarchive' : 'archive', child: Text(dream.archived ? 'アーカイブ解除' : 'アーカイブ')),
+                PopupMenuItem(
+                    value: dream.archived ? 'unarchive' : 'archive',
+                    child: Text(dream.archived ? 'アーカイブ解除' : 'アーカイブ')),
                 const PopupMenuItem(value: 'delete', child: Text('削除')),
               ],
             ),
@@ -155,7 +162,7 @@ class TermTile extends ConsumerWidget {
             children: [
               const Text('TODOはTODOタブから管理'),
               const SizedBox(height: 4),
-              _GoalTagChips(item: item),
+              _TermTagChips(item: item),
             ],
           ),
           trailing: Row(
@@ -164,7 +171,7 @@ class TermTile extends ConsumerWidget {
               IconButton(
                 tooltip: 'タグを編集',
                 icon: const Icon(Icons.label),
-                onPressed: () => _editGoalTags(context, ref, item),
+                onPressed: () => _editTermTags(context, ref, item),
               ),
               IconButton(
                 icon: const Icon(Icons.add),
@@ -173,24 +180,29 @@ class TermTile extends ConsumerWidget {
                   if (title != null) {
                     final dreamId = item.dreamId;
                     if (dreamId == null) return;
-                    await ref
-                        .read(termRepoProvider)
-                        .addTerm(title: title, dreamId: dreamId, parentGoalId: item.id);
-                    }
-                  },
+                    await ref.read(termRepoProvider).addTerm(
+                        title: title, dreamId: dreamId, parentId: item.id);
+                  }
+                },
               ),
               PopupMenuButton<String>(
                 onSelected: (v) async {
                   if (v == 'archive') {
-                    await ref.read(termRepoProvider).archiveTerm(item, archived: true);
+                    await ref
+                        .read(termRepoProvider)
+                        .archiveTerm(item, archived: true);
                   } else if (v == 'unarchive') {
-                    await ref.read(termRepoProvider).archiveTerm(item, archived: false);
+                    await ref
+                        .read(termRepoProvider)
+                        .archiveTerm(item, archived: false);
                   } else if (v == 'delete') {
                     await ref.read(termRepoProvider).deleteTerm(item);
                   }
                 },
                 itemBuilder: (context) => [
-                  PopupMenuItem(value: item.archived ? 'unarchive' : 'archive', child: Text(item.archived ? 'アーカイブ解除' : 'アーカイブ')),
+                  PopupMenuItem(
+                      value: item.archived ? 'unarchive' : 'archive',
+                      child: Text(item.archived ? 'アーカイブ解除' : 'アーカイブ')),
                   const PopupMenuItem(value: 'delete', child: Text('削除')),
                 ],
               ),
@@ -207,7 +219,7 @@ class TermTile extends ConsumerWidget {
                 child: Text('エラー: $e'),
               ),
               data: (items) => Column(
-              children: items.map((s) => TermChildTile(item: s)).toList(),
+                children: items.map((s) => TermChildTile(item: s)).toList(),
               ),
             ),
           ],
@@ -230,7 +242,7 @@ class TermChildTile extends ConsumerWidget {
         children: [
           const Text('タップで配下TODOのCRUD'),
           const SizedBox(height: 4),
-          _GoalTagChips(item: item),
+          _TermTagChips(item: item),
         ],
       ),
       trailing: Row(
@@ -239,20 +251,26 @@ class TermChildTile extends ConsumerWidget {
           IconButton(
             tooltip: 'タグを編集',
             icon: const Icon(Icons.label),
-            onPressed: () => _editGoalTags(context, ref, item),
+            onPressed: () => _editTermTags(context, ref, item),
           ),
           PopupMenuButton<String>(
             onSelected: (v) async {
               if (v == 'archive') {
-                await ref.read(termRepoProvider).archiveTerm(item, archived: true);
+                await ref
+                    .read(termRepoProvider)
+                    .archiveTerm(item, archived: true);
               } else if (v == 'unarchive') {
-                await ref.read(termRepoProvider).archiveTerm(item, archived: false);
+                await ref
+                    .read(termRepoProvider)
+                    .archiveTerm(item, archived: false);
               } else if (v == 'delete') {
                 await ref.read(termRepoProvider).deleteTerm(item);
               }
             },
             itemBuilder: (context) => [
-              PopupMenuItem(value: item.archived ? 'unarchive' : 'archive', child: Text(item.archived ? 'アーカイブ解除' : 'アーカイブ')),
+              PopupMenuItem(
+                  value: item.archived ? 'unarchive' : 'archive',
+                  child: Text(item.archived ? 'アーカイブ解除' : 'アーカイブ')),
               const PopupMenuItem(value: 'delete', child: Text('削除')),
             ],
           ),
@@ -262,14 +280,15 @@ class TermChildTile extends ConsumerWidget {
         context: context,
         useSafeArea: true,
         isScrollControlled: true,
-        builder: (context) => TermDetailSheet(goalId: item.id, title: item.title),
+        builder: (context) =>
+            TermDetailSheet(termId: item.id, title: item.title),
       ),
     );
   }
 }
 
-class _GoalTagChips extends ConsumerWidget {
-  const _GoalTagChips({required this.item});
+class _TermTagChips extends ConsumerWidget {
+  const _TermTagChips({required this.item});
   final Term item;
 
   @override
@@ -297,7 +316,8 @@ class _GoalTagChips extends ConsumerWidget {
   }
 }
 
-Future<void> _editGoalTags(BuildContext context, WidgetRef ref, Term item) async {
+Future<void> _editTermTags(
+    BuildContext context, WidgetRef ref, Term item) async {
   final selected = await ref.read(termRepoProvider).loadTags(item);
   final allTags = await ref.read(tagRepoProvider).watchAll().first;
   final result = await showDialog<List<Tag>>(
@@ -350,16 +370,21 @@ class _TagPickerDialogState extends State<_TagPickerDialog> {
                             });
                           },
                           title: Text(t.name),
-                          secondary: CircleAvatar(backgroundColor: Color(t.color)),
+                          secondary:
+                              CircleAvatar(backgroundColor: Color(t.color)),
                         ))
                     .toList(),
               ),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
         FilledButton(
           onPressed: () {
-            final result = widget.allTags.where((t) => _selectedIds.contains(t.id)).toList();
+            final result = widget.allTags
+                .where((t) => _selectedIds.contains(t.id))
+                .toList();
             Navigator.pop(context, result);
           },
           child: const Text('保存'),
@@ -370,8 +395,8 @@ class _TagPickerDialogState extends State<_TagPickerDialog> {
 }
 
 class TermDetailSheet extends ConsumerWidget {
-  const TermDetailSheet({super.key, required this.goalId, required this.title});
-  final int goalId;
+  const TermDetailSheet({super.key, required this.termId, required this.title});
+  final int termId;
   final String title;
 
   @override
@@ -380,22 +405,24 @@ class TermDetailSheet extends ConsumerWidget {
     return DraggableScrollableSheet(
       expand: false,
       builder: (context, controller) {
-        return _TermDetailList(goalId: goalId, title: title, controller: controller);
+        return _TermDetailList(
+            termId: termId, title: title, controller: controller);
       },
     );
   }
 }
 
 class _TermDetailList extends ConsumerWidget {
-  const _TermDetailList({required this.goalId, required this.title, required this.controller});
-  final int goalId;
+  const _TermDetailList(
+      {required this.termId, required this.title, required this.controller});
+  final int termId;
   final String title;
   final ScrollController controller;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final taskRepo = ref.read(taskRepoProvider);
-    final stream = taskRepo.watchByGoal(goalId);
+    final stream = taskRepo.watchByTerm(termId);
     return StreamBuilder(
       stream: stream,
       builder: (context, snapshot) {
@@ -415,7 +442,7 @@ class _TermDetailList extends ConsumerWidget {
                       final title = await _askTitle(context, 'TODOを追加');
                       if (title != null) {
                         final t = await taskRepo.addQuick(title);
-                        t.shortTermId = goalId; // unified: tasks link to goalId
+                        t.shortTermId = termId; // unified: tasks link to termId
                         await taskRepo.update(t);
                       }
                     },
@@ -462,8 +489,12 @@ Future<String?> _askTitle(BuildContext context, String title) async {
         onSubmitted: (_) => Navigator.of(context).pop(controller.text.trim()),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
-        FilledButton(onPressed: () => Navigator.pop(context, controller.text.trim()), child: const Text('追加')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
+        FilledButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('追加')),
       ],
     ),
   );

--- a/lib/ui/terms/terms_page.dart
+++ b/lib/ui/terms/terms_page.dart
@@ -171,11 +171,13 @@ class TermTile extends ConsumerWidget {
                 onPressed: () async {
                   final title = await _askTitle(context, 'Termを追加');
                   if (title != null) {
-                    final dreamId = item.dreamId ?? (await ref.read(longTermRepoProvider).getById(item.id))?.dreamId;
+                    final dreamId = item.dreamId;
                     if (dreamId == null) return;
-                    await ref.read(termRepoProvider).addTerm(title: title, dreamId: dreamId, parentGoalId: item.id);
-                  }
-                },
+                    await ref
+                        .read(termRepoProvider)
+                        .addTerm(title: title, dreamId: dreamId, parentGoalId: item.id);
+                    }
+                  },
               ),
               PopupMenuButton<String>(
                 onSelected: (v) async {
@@ -303,7 +305,7 @@ Future<void> _editGoalTags(BuildContext context, WidgetRef ref, Term item) async
     builder: (context) => _TagPickerDialog(allTags: allTags, initial: selected),
   );
   if (result != null) {
-    await ref.read(termRepoProvider).setTags(item, result);
+    await ref.read(termRepoProvider).updateTerm(item, result);
   }
 }
 

--- a/lib/ui/todo/term_todo_page.dart
+++ b/lib/ui/todo/term_todo_page.dart
@@ -9,15 +9,16 @@ import '../../providers/term_providers.dart';
 import '../widgets/task_tile.dart';
 
 class TermTodoPage extends ConsumerWidget {
-  const TermTodoPage({super.key, required this.goalId, required this.goalTitle});
-  final int goalId;
-  final String goalTitle;
+  const TermTodoPage(
+      {super.key, required this.termId, required this.termTitle});
+  final int termId;
+  final String termTitle;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final repo = ref.read(taskRepoProvider);
-    final goalWithTags = ref.watch(termWithTagsProvider(goalId));
-    final shortsAsync = ref.watch(termsByParentProvider(goalId));
+    final termWithTags = ref.watch(termWithTagsProvider(termId));
+    final shortsAsync = ref.watch(termsByParentProvider(termId));
 
     String priorityLabel(int p) {
       switch (p) {
@@ -52,7 +53,7 @@ class TermTodoPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(goalWithTags.asData?.value?.item.title ?? goalTitle),
+        title: Text(termWithTags.asData?.value?.item.title ?? termTitle),
         actions: [
           IconButton(
             tooltip: 'TODOを追加',
@@ -65,13 +66,13 @@ class TermTodoPage extends ConsumerWidget {
               int? targetId;
               if (shorts.isEmpty) {
                 // 子Termがない場合は、このTerm直下に作成
-                targetId = goalId;
+                targetId = termId;
               } else {
                 // このTerm直下 も選択肢に含めて選ばせる
                 targetId = await _pickTargetTerm(
                   context,
-                  currentTermId: goalId,
-                  currentTermTitle: goalTitle,
+                  currentTermId: termId,
+                  currentTermTitle: termTitle,
                   children: shorts,
                 );
               }
@@ -81,7 +82,7 @@ class TermTodoPage extends ConsumerWidget {
           ),
         ],
       ),
-      body: goalWithTags.when(
+      body: termWithTags.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('読み込みエラー: $e')),
         data: (gwt) {
@@ -92,7 +93,7 @@ class TermTodoPage extends ConsumerWidget {
           final tags = gwt.tags;
           return Column(
             children: [
-              // Header: goal details
+              // Header: term details
               Card(
                 margin: const EdgeInsets.all(12),
                 child: Padding(
@@ -108,16 +109,23 @@ class TermTodoPage extends ConsumerWidget {
                       Row(
                         children: [
                           Container(
-                            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 4),
                             decoration: BoxDecoration(
-                              color: priorityColor(item.priority, context).withOpacity(0.1),
+                              color: priorityColor(item.priority, context)
+                                  .withOpacity(0.1),
                               borderRadius: BorderRadius.circular(8),
-                              border: Border.all(color: priorityColor(item.priority, context).withOpacity(0.3)),
+                              border: Border.all(
+                                  color: priorityColor(item.priority, context)
+                                      .withOpacity(0.3)),
                             ),
                             child: Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
-                                Icon(Icons.flag, size: 16, color: priorityColor(item.priority, context)),
+                                Icon(Icons.flag,
+                                    size: 16,
+                                    color:
+                                        priorityColor(item.priority, context)),
                                 const SizedBox(width: 6),
                                 Text('優先度: ${priorityLabel(item.priority)}'),
                               ],
@@ -125,10 +133,14 @@ class TermTodoPage extends ConsumerWidget {
                           ),
                           const SizedBox(width: 12),
                           Container(
-                            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 4),
                             decoration: BoxDecoration(
                               borderRadius: BorderRadius.circular(8),
-                              border: Border.all(color: Theme.of(context).dividerColor.withOpacity(0.5)),
+                              border: Border.all(
+                                  color: Theme.of(context)
+                                      .dividerColor
+                                      .withOpacity(0.5)),
                             ),
                             child: Row(
                               mainAxisSize: MainAxisSize.min,
@@ -156,7 +168,8 @@ class TermTodoPage extends ConsumerWidget {
                               .toList(),
                         ),
                       ] else ...[
-                        Text('タグ: なし', style: Theme.of(context).textTheme.bodySmall),
+                        Text('タグ: なし',
+                            style: Theme.of(context).textTheme.bodySmall),
                       ],
                     ],
                   ),
@@ -164,14 +177,19 @@ class TermTodoPage extends ConsumerWidget {
               ),
               Expanded(
                 child: shortsAsync.when(
-                  loading: () => const Center(child: CircularProgressIndicator()),
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
                   error: (e, _) => Center(child: Text('読み込みエラー: $e')),
                   data: (shorts) {
                     // このTerm直下と子Term直下の両方を表示対象にする
-                    final shortIds = shorts.map((s) => s.id).toSet()..add(goalId);
-                    final tasks = ref.watch(tasksStreamProvider).value ?? const <Task>[];
+                    final shortIds = shorts.map((s) => s.id).toSet()
+                      ..add(termId);
+                    final tasks =
+                        ref.watch(tasksStreamProvider).value ?? const <Task>[];
                     final items = tasks
-                        .where((t) => t.shortTermId != null && shortIds.contains(t.shortTermId))
+                        .where((t) =>
+                            t.shortTermId != null &&
+                            shortIds.contains(t.shortTermId))
                         .toList();
                     if (items.isEmpty) {
                       return const Center(child: Text('TODOはありません'));
@@ -179,7 +197,8 @@ class TermTodoPage extends ConsumerWidget {
                     return ListView.builder(
                       itemCount: items.length,
                       itemBuilder: (context, i) => Card(
-                        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                        margin: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 6),
                         child: TaskTile(task: items[i]),
                       ),
                     );
@@ -207,14 +226,21 @@ Future<String?> _askTitle(BuildContext context, String title) async {
         onSubmitted: (_) => Navigator.of(context).pop(controller.text.trim()),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
-        FilledButton(onPressed: () => Navigator.pop(context, controller.text.trim()), child: const Text('追加')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
+        FilledButton(
+            onPressed: () => Navigator.pop(context, controller.text.trim()),
+            child: const Text('追加')),
       ],
     ),
   );
 }
 
-Future<int?> _pickTargetTerm(BuildContext context, {required int currentTermId, required String currentTermTitle, required List<Term> children}) async {
+Future<int?> _pickTargetTerm(BuildContext context,
+    {required int currentTermId,
+    required String currentTermTitle,
+    required List<Term> children}) async {
   int? selectedId = currentTermId;
   return showDialog<int>(
     context: context,
@@ -242,7 +268,9 @@ Future<int?> _pickTargetTerm(BuildContext context, {required int currentTermId, 
         ),
       ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: const Text('キャンセル')),
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('キャンセル')),
         FilledButton(
           onPressed: () {
             Navigator.pop(context, selectedId);

--- a/lib/ui/todo/todo_page.dart
+++ b/lib/ui/todo/todo_page.dart
@@ -161,7 +161,7 @@ class _LongFilteredSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Show tasks linked directly to this Term (LongTerm.id)
+    // Show tasks linked directly to this Term
     return FutureBuilder(
       future: ref.read(termRepoProvider).loadTags(item),
       builder: (context, snap) {

--- a/lib/ui/todo/todo_page.dart
+++ b/lib/ui/todo/todo_page.dart
@@ -38,7 +38,8 @@ class _TodoTree extends ConsumerStatefulWidget {
   ConsumerState<_TodoTree> createState() => _TodoTreeState();
 }
 
-class _TodoTreeState extends ConsumerState<_TodoTree> with TickerProviderStateMixin {
+class _TodoTreeState extends ConsumerState<_TodoTree>
+    with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final dreams = ref.watch(dreamsProvider).value ?? const <Dream>[];
@@ -46,11 +47,13 @@ class _TodoTreeState extends ConsumerState<_TodoTree> with TickerProviderStateMi
 
     final dreamTabs = [
       const Tab(icon: Icon(Icons.bedtime_outlined), text: '夢: すべて'),
-      ...dreams.map((d) => Tab(icon: const Icon(Icons.bedtime_outlined), text: d.title)),
+      ...dreams.map(
+          (d) => Tab(icon: const Icon(Icons.bedtime_outlined), text: d.title)),
     ];
     final tagTabs = [
       const Tab(icon: Icon(Icons.label_outline), text: 'タグ: すべて'),
-      ...tags.map((t) => Tab(icon: const Icon(Icons.label_outline), text: t.name)),
+      ...tags
+          .map((t) => Tab(icon: const Icon(Icons.label_outline), text: t.name)),
     ];
 
     return Theme(
@@ -64,7 +67,8 @@ class _TodoTreeState extends ConsumerState<_TodoTree> with TickerProviderStateMi
               animation: dreamCtrl,
               builder: (context, _) {
                 final dreamIndex = dreamCtrl.index;
-                final selectedDreamId = dreamIndex == 0 ? null : dreams[dreamIndex - 1].id;
+                final selectedDreamId =
+                    dreamIndex == 0 ? null : dreams[dreamIndex - 1].id;
                 return Column(
                   children: [
                     Material(
@@ -72,7 +76,8 @@ class _TodoTreeState extends ConsumerState<_TodoTree> with TickerProviderStateMi
                       child: TabBar(
                         isScrollable: true,
                         tabs: dreamTabs,
-                        labelPadding: const EdgeInsets.symmetric(horizontal: 16),
+                        labelPadding:
+                            const EdgeInsets.symmetric(horizontal: 16),
                       ),
                     ),
                     Expanded(
@@ -85,15 +90,20 @@ class _TodoTreeState extends ConsumerState<_TodoTree> with TickerProviderStateMi
                               animation: tagCtrl,
                               builder: (context, __) {
                                 final tagIndex = tagCtrl.index;
-                                final selectedTagId = tagIndex == 0 ? null : tags[tagIndex - 1].id;
+                                final selectedTagId = tagIndex == 0
+                                    ? null
+                                    : tags[tagIndex - 1].id;
                                 return Column(
                                   children: [
                                     Material(
-                                      color: Theme.of(context).colorScheme.surface,
+                                      color:
+                                          Theme.of(context).colorScheme.surface,
                                       child: TabBar(
                                         isScrollable: true,
                                         tabs: tagTabs,
-                                        labelPadding: const EdgeInsets.symmetric(horizontal: 12),
+                                        labelPadding:
+                                            const EdgeInsets.symmetric(
+                                                horizontal: 12),
                                       ),
                                     ),
                                     Expanded(
@@ -154,7 +164,8 @@ class _FilteredTodosView extends ConsumerWidget {
 }
 
 class _LongFilteredSection extends ConsumerWidget {
-  const _LongFilteredSection({required this.item, required this.tagId, required this.allTasks});
+  const _LongFilteredSection(
+      {required this.item, required this.tagId, required this.allTasks});
   final Term item;
   final int? tagId;
   final List<Task> allTasks;
@@ -166,12 +177,14 @@ class _LongFilteredSection extends ConsumerWidget {
       future: ref.read(termRepoProvider).loadTags(item),
       builder: (context, snap) {
         final tags = snap.data ?? const <Tag>[];
-        final goalHasTag = tagId == null ? true : tags.any((t) => t.id == tagId);
-        if (!goalHasTag && tagId != null) {
+        final termHasTag =
+            tagId == null ? true : tags.any((t) => t.id == tagId);
+        if (!termHasTag && tagId != null) {
           return const SizedBox.shrink();
         }
 
-        final filteredTasks = allTasks.where((t) => t.shortTermId == item.id).toList();
+        final filteredTasks =
+            allTasks.where((t) => t.shortTermId == item.id).toList();
 
         return Card(
           child: ExpansionTile(
@@ -181,7 +194,8 @@ class _LongFilteredSection extends ConsumerWidget {
               onTap: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(
-                    builder: (_) => TermTodoPage(goalId: item.id, goalTitle: item.title),
+                    builder: (_) =>
+                        TermTodoPage(termId: item.id, termTitle: item.title),
                   ),
                 );
               },
@@ -189,9 +203,10 @@ class _LongFilteredSection extends ConsumerWidget {
             ),
             subtitle: Text('TODO ${filteredTasks.length} 件'),
             children: [
-          // Term actions row
+              // Term actions row
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
                 child: Row(
                   children: [
                     OutlinedButton.icon(
@@ -200,7 +215,9 @@ class _LongFilteredSection extends ConsumerWidget {
                       onPressed: item.archived
                           ? null
                           : () async {
-                              await ref.read(termRepoProvider).archiveTerm(item, archived: true);
+                              await ref
+                                  .read(termRepoProvider)
+                                  .archiveTerm(item, archived: true);
                             },
                     ),
                   ],
@@ -214,7 +231,8 @@ class _LongFilteredSection extends ConsumerWidget {
               else
                 ...filteredTasks
                     .map<Widget>((t) => Card(
-                          margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                          margin: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 4),
                           child: TaskTile(task: t),
                         ))
                     .toList(),
@@ -273,7 +291,8 @@ class _LongNode extends ConsumerWidget {
             onTap: () {
               Navigator.of(context).push(
                 MaterialPageRoute(
-                    builder: (_) => TermTodoPage(goalId: item.id, goalTitle: item.title),
+                  builder: (_) =>
+                      TermTodoPage(termId: item.id, termTitle: item.title),
                 ),
               );
             },
@@ -293,7 +312,11 @@ class _LongNode extends ConsumerWidget {
               data: (shorts) {
                 final shortIds = shorts.map((s) => s.id).toSet();
                 final tasks = tasksAsync.value ?? const <Task>[];
-                final filtered = tasks.where((t) => t.shortTermId != null && shortIds.contains(t.shortTermId)).toList();
+                final filtered = tasks
+                    .where((t) =>
+                        t.shortTermId != null &&
+                        shortIds.contains(t.shortTermId))
+                    .toList();
                 if (filtered.isEmpty) {
                   return const Padding(
                     padding: EdgeInsets.all(12.0),
@@ -303,7 +326,8 @@ class _LongNode extends ConsumerWidget {
                 return Column(
                   children: filtered
                       .map<Widget>((t) => Card(
-                            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                            margin: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 4),
                             child: TaskTile(task: t),
                           ))
                       .toList(),
@@ -316,5 +340,3 @@ class _LongNode extends ConsumerWidget {
     );
   }
 }
-
- 


### PR DESCRIPTION
## Summary
- remove remaining LongTerm/ShortTerm providers and wire up a single TermRepository
- expose general Term model with lookups and updates
- refactor UI and task repository to rely on unified Term API

## Testing
- `flutter test` *(fails: Couldn't find constructor 'MyApp')*

------
https://chatgpt.com/codex/tasks/task_e_68aba1ee08448332bb4108ff0cd23ede